### PR TITLE
dns: More reliable DNS configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DAEMON_NAME=velesd
 test_all:
 	@make test_install
 	@make test_env
+	@make test_dns
 
 test_install:
 	@echo
@@ -21,6 +22,24 @@ test_env:
 	@echo -n '[test_env] Testing internet connection and DNS ... '
 	ping google.com -c 5 && echo 'ok' || ( echo -e "fail\n, DNS debug: " ; dig google.com ; exit 1 )
 	@echo "[test_env] Done [success]"
+
+test_dns:
+	@echo -n '[test_dns] Checking DNS settings ...'
+	@echo -n 'Checking /etc/systemd/resolved.conf ... '
+	@if [ -f /etc/systemd/resolved.conf ]; then\
+		grep "DNSStubListener=no" /etc/systemd/resolved.conf || ( echo 'fail' ; cat /etc/systemd/resolved.conf ; exit 1 );\
+		grep "DNS=127\.0\.0\.1" /etc/systemd/resolved.conf || ( echo 'fail' ; cat /etc/systemd/resolved.conf ; exit 1 );\
+		echo "ok";\
+	else\
+		echo "not present";\
+	fi
+	@echo -n 'Checking /etc/dnsmasq.conf ... '
+	@if [ -f /etc/dnsmasq.conf ]; then\
+		grep "port=53" /etc/dnsmasq.conf && ( echo 'fail' ; cat /etc/dnsmasq.conf ; exit 1 ) || echo "ok";\
+	else\
+		echo "not present";\
+	fi
+	@echo "[test_dns] Done [success]"
 
 docker_test_all:
 	@make install_docker_systemd

--- a/data/package/post_install.sh
+++ b/data/package/post_install.sh
@@ -25,6 +25,12 @@ do_post_install() {
 	systemctl daemon-reload
 	systemctl restart systemd-resolved
 
+	# Make sure local dnsmasq doesn't affect our DNS server either,
+	# if it gets enabled for some reason.
+	sed -i 's/#port=/port=35353/g' /etc/dnsmasq.conf
+	sed -i 's/port=53/port=35353/g' /etc/dnsmasq.conf
+	systemctl restart dnsmasq
+
 	## Update netfilter and ufw rules
 	# Packet forwarding
 	sed -i 's/^[# ]*net.ipv4.ip_forward=.*$//g' /etc/sysctl.conf

--- a/data/package/post_install.sh
+++ b/data/package/post_install.sh
@@ -16,20 +16,28 @@ do_post_install() {
 	ln -s "/var/lib/veles/wallet/debug.log" "/var/log/veles/debug.log"
 
 	## We need to update systemd config in order to disable local DNS blocking port 53
-	sed -i 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
-	sed -i 's/DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
-	# And make sure local DNS resolution works at all the times
-	sed -i 's/#DNS=/DNS=127.0.0.1 /g' /etc/systemd/resolved.conf
-	sed -i 's/#FallbackDNS=/FallbackDNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4 /g' /etc/systemd/resolved.conf
-	# Make sure we reload systemd resolver settings
-	systemctl daemon-reload
-	systemctl restart systemd-resolved
+	if [ -f /etc/systemd/resolved.conf ]; then
+		echo "Warning: /etc/systemd/resolved.conf not found!"
+
+		sed -i 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
+		sed -i 's/DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
+
+		# And make sure local DNS resolution works at all the times
+		sed -i 's/#DNS=/DNS=127.0.0.1 /g' /etc/systemd/resolved.conf
+		sed -i 's/#FallbackDNS=/FallbackDNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4 /g' /etc/systemd/resolved.conf
+
+		# Make sure we reload systemd resolver settings
+		systemctl daemon-reload
+		systemctl restart systemd-resolved
+	fi
 
 	# Make sure local dnsmasq doesn't affect our DNS server either,
 	# if it gets enabled for some reason.
-	sed -i 's/#port=/port=35353/g' /etc/dnsmasq.conf
-	sed -i 's/port=53/port=35353/g' /etc/dnsmasq.conf
-	systemctl restart dnsmasq
+	if [ -f /etc/dnsmasq.conf ]; then
+		sed -i 's/#port=/port=35353/g' /etc/dnsmasq.conf
+		sed -i 's/port=53/port=35353/g' /etc/dnsmasq.conf
+		systemctl restart dnsmasq
+	fi
 
 	## Update netfilter and ufw rules
 	# Packet forwarding

--- a/data/package/post_install.sh
+++ b/data/package/post_install.sh
@@ -18,6 +18,10 @@ do_post_install() {
 	## We need to update systemd config in order to disable local DNS blocking port 53
 	sed -i 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
 	sed -i 's/DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
+	# And make sure local DNS resolution works at all the times
+	sed -i 's/#DNS=/DNS=127.0.0.1 /g' /etc/systemd/resolved.conf
+	sed -i 's/#FallbackDNS=/FallbackDNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4 /g' /etc/systemd/resolved.conf
+	# Make sure we reload systemd resolver settings
 	systemctl daemon-reload
 	systemctl restart systemd-resolved
 


### PR DESCRIPTION
- add extra settings and fallback to resolvd.conf to make sure MN doesn't loose DNS resolution capability 
- make sure default Ubuntu's dnsmasq doesn't listen local port 53 reserved for Veles MN dnsmasq
- automated tests (eg. for Travis CI) to validate DNS-related configuration files